### PR TITLE
Remove onClear from inputProps

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -121,6 +121,7 @@ export default class SearchBar extends Component {
       closeIcon,
       disabled,
       onRequestSearch,
+      onClear,
       searchIcon,
       style,
       ...inputProps


### PR DESCRIPTION
'onClear' is for use by SearchBar, and is not meant to be sent 
to AutoComplete (and further on to input).

This removes onClear from the props before sending to AutoComplete.

I tested this change in my application.