### PR TITLE
Fix import in usage example presented in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i --save material-ui-search-bar-enhanced
 
 ## Usage
 ```js
-import SearchBar from 'material-ui-search-bar'
+import SearchBar from 'material-ui-search-bar-enhanced'
 
 // ...
 render() {


### PR DESCRIPTION
Update example to import SearchBar from material-ui-search-bar-enhanced.