### PR TITLE
Remove Form field and type attribute within Autocomplete

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -136,24 +136,21 @@ export default class SearchBar extends Component {
         }}
       >
         <div style={styles.searchContainer}>
-          <form action=".">
-            <AutoComplete
-              type="search"
-              ref={ref => {
-                this.autoComplete = ref;
-              }}
-              onBlur={() => this.handleBlur()}
-              searchText={value}
-              onUpdateInput={e => this.handleInput(e)}
-              onKeyPress={e => this.handleKeyPressed(e)}
-              onFocus={() => this.handleFocus()}
-              fullWidth
-              style={styles.input}
-              underlineShow={false}
-              disabled={disabled}
-              {...inputProps}
-            />
-          </form>
+          <AutoComplete
+            ref={ref => {
+              this.autoComplete = ref;
+            }}
+            onBlur={() => this.handleBlur()}
+            searchText={value}
+            onUpdateInput={e => this.handleInput(e)}
+            onKeyPress={e => this.handleKeyPressed(e)}
+            onFocus={() => this.handleFocus()}
+            fullWidth
+            style={styles.input}
+            underlineShow={false}
+            disabled={disabled}
+            {...inputProps}
+          />
         </div>
         <IconButton
           onClick={onRequestSearch}


### PR DESCRIPTION
I don't believe that this change is necessary, as mobile users can already use their enter key on their keyboard to trigger the search. 

It also creates a duplicate close icon (as shown below).
![image](https://user-images.githubusercontent.com/20138310/38659012-7148d1b6-3df5-11e8-8677-6902c9c2b4ac.png)
